### PR TITLE
Update to Compose 5.0.3. and remove AppCompat related components

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,13 +47,11 @@ android {
 }
 
 dependencies {
-    implementation "io.getstream:stream-chat-android-compose:5.0.1"
+    implementation "io.getstream:stream-chat-android-compose:5.0.3"
 
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.activity:activity-compose:1.4.0"
-
-    implementation "com.google.android.material:material:1.5.0"
 }

--- a/app/src/main/java/com/example/chattutorial/MainActivity.kt
+++ b/app/src/main/java/com/example/chattutorial/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.example.chattutorial
 
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.res.stringResource
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
@@ -13,7 +13,7 @@ import io.getstream.chat.android.offline.model.message.attachments.UploadAttachm
 import io.getstream.chat.android.offline.plugin.configuration.Config
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity.kt
@@ -3,12 +3,12 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
-class MessagesActivity : AppCompatActivity() {
+class MessagesActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity2.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity2.kt
@@ -3,8 +3,8 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
@@ -12,7 +12,7 @@ import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamShapes
 
-class MessagesActivity2 : AppCompatActivity() {
+class MessagesActivity2 : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
@@ -3,9 +3,9 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,7 +37,7 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
-class MessagesActivity3 : AppCompatActivity() {
+class MessagesActivity3 : ComponentActivity() {
 
     // Build the ViewModel factory
     private val factory by lazy {

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
@@ -3,9 +3,9 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -46,7 +46,7 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
-class MessagesActivity4 : AppCompatActivity() {
+class MessagesActivity4 : ComponentActivity() {
 
     // Build the ViewModel factory
     private val factory by lazy {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,7 +19,7 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="Theme.ChatTutorial.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="Theme.ChatTutorial.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
 
-    <style name="Theme.ChatTutorial.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="Theme.ChatTutorial.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light" />
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "com.android.tools.build:gradle:7.1.3"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
     }
 }


### PR DESCRIPTION
A few things were done in this PR, please review them individually and report any that you think do not make sense

### 1. Updated Compose SDK dependency to 5.0.3

### 2. Switched from using `AppCompatActivity` to `ComponentActivity`

When you create a new Compose project, the standard automatically created Theme in AS Bumblebee and up is `MaterialComponents`. `AppCompatActivity` requires the App Theme to inherit from an `AppCompat` one. 

- We do not point this out to users so the experience could frustrate them when the app crashes at runtime
- There is no need for AppCompat related things in Compose only projects

Caveat: Users who try to implement chat in their existing applications and are using XML as well might have to do some extra work figuring things out, but this tutorial was not meant for that anyways so I don't think it lies within its responsibilities.

### 3. Switched Theme from an `AppCompat` one to a `MaterialComponents`

This is a positive consequence of `2.`

### 4. Removed the dependency that points to `com.google.android.material:material`

Both a positive consequence of `2.` and `3.` and something that should help the users since creating a new Jetpack Compose project will not auto import this dependency. We also do not point this out to the users.