### PR TITLE
Update Compose SDK dependency and remove `AppCompat`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,13 +47,11 @@ android {
 }
 
 dependencies {
-    implementation "io.getstream:stream-chat-android-compose:5.0.1"
+    implementation "io.getstream:stream-chat-android-compose:5.0.3"
 
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.activity:activity-compose:1.4.0"
-
-    implementation "com.google.android.material:material:1.5.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation "io.getstream:stream-chat-android-compose:5.0.3"
+    implementation "io.getstream:stream-chat-android-compose:5.1.0"
 
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-    implementation "io.getstream:stream-chat-android-compose:5.1.0"
+    implementation "io.getstream:stream-chat-android-compose:5.2.0"
 
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/app/src/main/java/com/example/chattutorial/MainActivity.kt
+++ b/app/src/main/java/com/example/chattutorial/MainActivity.kt
@@ -1,8 +1,8 @@
 package com.example.chattutorial
 
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.res.stringResource
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
@@ -13,7 +13,7 @@ import io.getstream.chat.android.offline.model.message.attachments.UploadAttachm
 import io.getstream.chat.android.offline.plugin.configuration.Config
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MainActivity.kt
+++ b/app/src/main/java/com/example/chattutorial/MainActivity.kt
@@ -51,6 +51,7 @@ class MainActivity : ComponentActivity() {
             ChatTheme {
                 ChannelsScreen(
                     title = stringResource(id = R.string.app_name),
+                    isShowingSearch = true,
                     onItemClick = { channel ->
                         startActivity(MessagesActivity4.getIntent(this, channel.cid))
                     },

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity.kt
@@ -3,12 +3,12 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
-class MessagesActivity : AppCompatActivity() {
+class MessagesActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity2.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity2.kt
@@ -3,8 +3,8 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
@@ -12,7 +12,7 @@ import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamShapes
 
-class MessagesActivity2 : AppCompatActivity() {
+class MessagesActivity2 : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
@@ -3,9 +3,9 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,7 +37,7 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
-class MessagesActivity3 : AppCompatActivity() {
+class MessagesActivity3 : ComponentActivity() {
 
     // Build the ViewModel factory
     private val factory by lazy {

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity3.kt
@@ -143,7 +143,8 @@ class MessagesActivity3 : ComponentActivity() {
                         messageOptions = defaultMessageOptionsState(
                             selectedMessage,
                             user,
-                            listViewModel.isInThread
+                            listViewModel.isInThread,
+                            selectedMessageState.ownCapabilities
                         ),
                         message = selectedMessage,
                         onMessageAction = { action ->
@@ -154,6 +155,7 @@ class MessagesActivity3 : ComponentActivity() {
                             listViewModel.selectExtendedReactions(selectedMessage)
                         },
                         onDismiss = { listViewModel.removeOverlay() },
+                        ownCapabilities = selectedMessageState.ownCapabilities
                     )
                 } else if (selectedMessageState is SelectedMessageReactionsState) {
                     SelectedReactionsMenu(
@@ -171,7 +173,8 @@ class MessagesActivity3 : ComponentActivity() {
                         onShowMoreReactionsSelected = {
                             listViewModel.selectExtendedReactions(selectedMessage)
                         },
-                        onDismiss = { listViewModel.removeOverlay() }
+                        onDismiss = { listViewModel.removeOverlay() },
+                        ownCapabilities = selectedMessageState.ownCapabilities
                     )
                 }
             }

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
@@ -3,9 +3,9 @@ package com.example.chattutorial
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -46,7 +46,7 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
-class MessagesActivity4 : AppCompatActivity() {
+class MessagesActivity4 : ComponentActivity() {
 
     // Build the ViewModel factory
     private val factory by lazy {

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
@@ -147,7 +147,8 @@ class MessagesActivity4 : ComponentActivity() {
                         messageOptions = defaultMessageOptionsState(
                             selectedMessage,
                             user,
-                            listViewModel.isInThread
+                            listViewModel.isInThread,
+                            selectedMessageState.ownCapabilities
                         ),
                         message = selectedMessage,
                         onMessageAction = { action ->
@@ -158,6 +159,7 @@ class MessagesActivity4 : ComponentActivity() {
                             listViewModel.selectExtendedReactions(selectedMessage)
                         },
                         onDismiss = { listViewModel.removeOverlay() },
+                        ownCapabilities = selectedMessageState.ownCapabilities
                     )
                 } else if (selectedMessageState is SelectedMessageReactionsState) {
                     SelectedReactionsMenu(
@@ -175,7 +177,8 @@ class MessagesActivity4 : ComponentActivity() {
                         onShowMoreReactionsSelected = {
                             listViewModel.selectExtendedReactions(selectedMessage)
                         },
-                        onDismiss = { listViewModel.removeOverlay() }
+                        onDismiss = { listViewModel.removeOverlay() },
+                        ownCapabilities = selectedMessageState.ownCapabilities
                     )
                 }
             }

--- a/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
+++ b/app/src/main/java/com/example/chattutorial/MessagesActivity4.kt
@@ -198,7 +198,8 @@ class MessagesActivity4 : ComponentActivity() {
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(7f)
-                        .padding(start = 8.dp),
+                        .padding(start = 8.dp)
+                        .align(Alignment.CenterVertically),
                     messageComposerState = inputState,
                     onValueChange = { composerViewModel.setMessageInput(it) },
                     onAttachmentRemoved = { composerViewModel.removeSelectedAttachment(it) },

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,7 +19,7 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="Theme.ChatTutorial.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="Theme.ChatTutorial.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar" />
 
-    <style name="Theme.ChatTutorial.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="Theme.ChatTutorial.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light" />
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "com.android.tools.build:gradle:7.1.3"
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.1.3"
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     }
 }
 


### PR DESCRIPTION
This is the same PR as [this](https://github.com/GetStream/compose-chat-tutorial/pull/10) one.
However the dependency was updated to `5.2.0` so the branch was renamed in order to keep consistency.

